### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Ancestry MCP Server
+[![smithery badge](https://smithery.ai/badge/mcp-server-ancestry)](https://smithery.ai/server/mcp-server-ancestry)
 [![MIT licensed][mit-badge]][mit-url]
 [![Python Version][python-badge]][python-url]
 [![PyPI version][pypi-badge]][pypi-url]
@@ -49,6 +50,15 @@ Python server implementing Model Context Protocol (MCP) for interactibility with
 
 ## Usage with Claude Desktop
 
+### Installing via Smithery
+
+To install Ancestry GEDCOM Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-server-ancestry):
+
+```bash
+npx -y @smithery/cli install mcp-server-ancestry --client claude
+```
+
+### Installing Manually
 1. First, install the package:
 ```pip install mcp-server-ancestry```
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Ancestry GEDCOM Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-server-ancestry

Let me know if any tweaks have to be made!